### PR TITLE
Update wallbox-pwn.py with longer BLE scanner time and print devices found to screen

### DIFF
--- a/wallbox-pwn.py
+++ b/wallbox-pwn.py
@@ -85,7 +85,9 @@ class WallboxBLE():
         return self.response
 
 async def main():
-    devices = await BleakScanner.discover()
+    devices = await BleakScanner.discover(10.0)
+    for d in devices:
+        print(d)
 
     # Find device
     wallboxes = [d for d in devices if d.name is not None and d.name.startswith("WB")]


### PR DESCRIPTION
Set a longer scan time (default time is too short) and print devices found to screen so user can see you are in fact detecting devices.